### PR TITLE
Replace any usage by safe casting

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_plugin/plugin.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_plugin/plugin.tsx
@@ -28,10 +28,15 @@ class EditorFramePlugin {
         );
       },
       registerDatasource: (name, datasource) => {
-        this.datasources[name] = datasource;
+        // casting it to an unknown datasource. This doesn't introduce runtime errors
+        // because each type T is always also an unknown, but typescript won't do it
+        // on it's own because we are loosing type information here.
+        // So it's basically explicitly saying "I'm dropping the information about type T here
+        // because this information isn't useful to me." but without using any which can leak
+        this.datasources[name] = datasource as Datasource<unknown>;
       },
       registerVisualization: (name, visualization) => {
-        this.visualizations[name] = visualization;
+        this.visualizations[name] = visualization as Visualization<unknown>;
       },
     };
   }

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -6,8 +6,9 @@
 
 export interface EditorFrameSetup {
   render: (domElement: Element) => void;
-  registerDatasource: (name: string, datasource: Datasource<any>) => void;
-  registerVisualization: (name: string, visualization: Visualization<any>) => void;
+  // generic type on the API functions to pull the "unknown vs. specific type" error into the implementation
+  registerDatasource: <T>(name: string, datasource: Datasource<T>) => void;
+  registerVisualization: <T>(name: string, visualization: Visualization<T>) => void;
 }
 
 export interface EditorFrameState {


### PR DESCRIPTION
This handles the problem with unknown without using any which always brings the danger of leaking somewhere and causing runtime problems.

If we want to enforce that internal state is always an object, we can also replace all `unknown`s by `object` - but I'm not convinced that's necessary. If a visualization can work with internal state just being a string, that should be fine (and I think we will get to this use case).

This PR is just for illustrative purposes, not for merging