### PR TITLE
Pass new saved object by ref

### DIFF
--- a/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/app.tsx
@@ -62,6 +62,8 @@ export function App({
     indexPatternTitles: [],
   });
 
+  const [isDirty, setDirty] = useState(false);
+
   const lastKnownDocRef = useRef<Document | undefined>(undefined);
 
   useEffect(() => {
@@ -97,7 +99,7 @@ export function App({
   // Can save if the frame has told us what it has, and there is either:
   // a) No saved doc
   // b) A saved doc that differs from the frame state
-  const isSaveable = true;
+  const isSaveable = isDirty;
     // state.lastKnownDoc &&
     // (!state.persistedDoc ||
     //   (state.persistedDoc && !_.isEqual(state.lastKnownDoc, state.persistedDoc)));
@@ -130,6 +132,7 @@ export function App({
                             ...state,
                             persistedDoc: newDoc,
                           });
+                          setDirty(false);
                           if (docId !== id) {
                             redirectTo(id);
                           }
@@ -193,6 +196,10 @@ export function App({
                     ...state,
                     indexPatternTitles,
                   });
+                }
+                const docChanged = !_.isEqual(doc, state.persistedDoc);
+                if (docChanged !== isDirty) {
+                  setDirty(docChanged);
                 }
                 lastKnownDocRef.current = doc;
               },


### PR DESCRIPTION
This PR avoids changing state on the app by moving the saved object into a ref. See https://github.com/elastic/kibana/pull/42031#discussion_r309635044

The performance gain looks good to me:

This is the flame chart when typing in a label input in a dimension panel popover on `lens/filter-bar`. One keypress takes ~55ms
<img width="1254" alt="Screenshot 2019-08-06 at 07 29 32" src="https://user-images.githubusercontent.com/1508364/62513591-e6a9e600-b81c-11e9-9b48-4674dfc5391a.png">

This is the flame chart for `lens/filter-bar-by-ref`. One keypress takes ~30ms
<img width="634" alt="Screenshot 2019-08-06 at 07 28 15" src="https://user-images.githubusercontent.com/1508364/62513687-283a9100-b81d-11e9-88aa-28fe713d5f01.png">