### PR TITLE
Use correct lifecycle hooks

### DIFF
--- a/x-pack/legacy/plugins/lens/public/app_plugin/plugin.tsx
+++ b/x-pack/legacy/plugins/lens/public/app_plugin/plugin.tsx
@@ -9,7 +9,7 @@ import { I18nProvider, FormattedMessage } from '@kbn/i18n/react';
 import { HashRouter, Switch, Route, RouteComponentProps } from 'react-router-dom';
 import chrome from 'ui/chrome';
 import { Storage } from 'ui/storage';
-import { editorFrameSetup, editorFrameStop } from '../editor_frame_plugin';
+import { editorFrameSetup, editorFrameStart, editorFrameStop } from '../editor_frame_plugin';
 import { indexPatternDatasourceSetup, indexPatternDatasourceStop } from '../indexpattern_plugin';
 import { SavedObjectIndexStore } from '../persistence';
 import { xyVisualizationSetup, xyVisualizationStop } from '../xy_visualization_plugin';
@@ -23,6 +23,7 @@ import { EditorFrameInstance } from '../types';
 
 export class AppPlugin {
   private instance: EditorFrameInstance | null = null;
+  private store: SavedObjectIndexStore | null = null;
 
   constructor() {}
 
@@ -33,15 +34,25 @@ export class AppPlugin {
     const datatableVisualization = datatableVisualizationSetup();
     const xyVisualization = xyVisualizationSetup();
     const metricVisualization = metricVisualizationSetup();
-    const editorFrame = editorFrameSetup();
-    const store = new SavedObjectIndexStore(chrome!.getSavedObjectsClient());
+    const editorFrameSetupInterface = editorFrameSetup();
+    this.store = new SavedObjectIndexStore(chrome!.getSavedObjectsClient());
 
-    editorFrame.registerDatasource('indexpattern', indexPattern);
-    editorFrame.registerVisualization(xyVisualization);
-    editorFrame.registerVisualization(datatableVisualization);
-    editorFrame.registerVisualization(metricVisualization);
+    editorFrameSetupInterface.registerDatasource('indexpattern', indexPattern);
+    editorFrameSetupInterface.registerVisualization(xyVisualization);
+    editorFrameSetupInterface.registerVisualization(datatableVisualization);
+    editorFrameSetupInterface.registerVisualization(metricVisualization);
+  }
 
-    this.instance = editorFrame.createInstance({});
+  start() {
+    if (this.store === null) {
+      throw new Error('Start lifecycle called before setup lifecycle');
+    }
+
+    const store = this.store;
+
+    const editorFrameStartInterface = editorFrameStart();
+
+    this.instance = editorFrameStartInterface.createInstance({});
 
     const renderEditor = (routeProps: RouteComponentProps<{ id?: string }>) => {
       return (
@@ -97,4 +108,5 @@ export class AppPlugin {
 const app = new AppPlugin();
 
 export const appSetup = () => app.setup();
+export const appStart = () => app.start();
 export const appStop = () => app.stop();

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/embeddable/embeddable_factory.ts
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/embeddable/embeddable_factory.ts
@@ -29,13 +29,9 @@ export class EmbeddableFactory extends AbstractEmbeddableFactory {
 
   private chrome: Chrome;
   private indexPatternService: IndexPatterns;
-  private expressionRenderer: ExpressionRenderer;
+  private expressionRenderer: ExpressionRenderer | null = null;
 
-  constructor(
-    chrome: Chrome,
-    expressionRenderer: ExpressionRenderer,
-    indexPatternService: IndexPatterns
-  ) {
+  constructor(chrome: Chrome, indexPatternService: IndexPatterns) {
     super({
       savedObjectMetaData: {
         name: i18n.translate('xpack.lens.lensSavedObjectLabel', {
@@ -47,7 +43,10 @@ export class EmbeddableFactory extends AbstractEmbeddableFactory {
     });
     this.chrome = chrome;
     this.indexPatternService = indexPatternService;
-    this.expressionRenderer = expressionRenderer;
+  }
+
+  public setExpressionRenderer(renderer: ExpressionRenderer) {
+    this.expressionRenderer = renderer;
   }
 
   public isEditable() {
@@ -69,6 +68,12 @@ export class EmbeddableFactory extends AbstractEmbeddableFactory {
     input: Partial<EmbeddableInput> & { id: string },
     parent?: IContainer
   ) {
+    if (this.expressionRenderer === null) {
+      throw new Error(
+        'Cannot initialize embeddables before expression renderer is provided. Make sure the `start` lifecycle is completed.'
+      );
+    }
+
     const store = new SavedObjectIndexStore(this.chrome.getSavedObjectsClient());
     const savedVis = await store.load(savedObjectId);
 

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/mocks.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/mocks.tsx
@@ -6,11 +6,15 @@
 
 import React from 'react';
 import { ExpressionRendererProps } from 'src/legacy/core_plugins/data/public';
-import { setup as data } from '../../../../../../src/legacy/core_plugins/data/public/legacy';
+import {
+  setup as dataSetup,
+  start as dataStart,
+} from '../../../../../../src/legacy/core_plugins/data/public/legacy';
 import { DatasourcePublicAPI, FramePublicAPI, Visualization, Datasource } from '../types';
-import { EditorFrameSetupPlugins } from './plugin';
+import { EditorFrameSetupPlugins, EditorFrameStartPlugins } from './plugin';
 
-type DataSetup = typeof data;
+type DataSetup = typeof dataSetup;
+type DataStart = typeof dataStart;
 
 export function createMockVisualization(): jest.Mocked<Visualization> {
   return {
@@ -80,8 +84,12 @@ export function createMockFramePublicAPI(): FrameMock {
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export type MockedDependencies = Omit<EditorFrameSetupPlugins, 'data'> & {
+export type MockedSetupDependencies = Omit<EditorFrameSetupPlugins, 'data'> & {
   data: Omit<DataSetup, 'expressions'> & { expressions: jest.Mocked<DataSetup['expressions']> };
+};
+
+export type MockedStartDependencies = Omit<EditorFrameStartPlugins, 'data'> & {
+  data: Omit<DataSetup, 'expressions'> & { expressions: jest.Mocked<DataStart['expressions']> };
 };
 
 export function createExpressionRendererMock(): jest.Mock<
@@ -91,9 +99,9 @@ export function createExpressionRendererMock(): jest.Mock<
   return jest.fn(_ => <span />);
 }
 
-export function createMockDependencies() {
+export function createMockSetupDependencies() {
   return ({
-    dataSetup: {
+    data: {
       indexPatterns: {
         indexPatterns: {},
       },
@@ -102,17 +110,21 @@ export function createMockDependencies() {
         registerRenderer: jest.fn(),
       },
     },
-    dataStart: {
-      expressions: {
-        ExpressionRenderer: createExpressionRendererMock(),
-        run: jest.fn(_ => Promise.resolve({ type: 'render', as: 'test', value: undefined })),
-      },
-    },
     embeddables: {
       registerEmbeddableFactory: jest.fn(),
     },
     chrome: {
       getSavedObjectsClient: () => {},
     },
-  } as unknown) as MockedDependencies;
+  } as unknown) as MockedSetupDependencies;
+}
+
+export function createMockStartDependencies() {
+  return ({
+    data: {
+      expressions: {
+        ExpressionRenderer: jest.fn(() => null),
+      },
+    },
+  } as unknown) as MockedStartDependencies;
 }

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.test.tsx
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/plugin.test.tsx
@@ -5,7 +5,12 @@
  */
 
 import { EditorFramePlugin } from './plugin';
-import { createMockDependencies, MockedDependencies } from './mocks';
+import {
+  MockedSetupDependencies,
+  MockedStartDependencies,
+  createMockSetupDependencies,
+  createMockStartDependencies,
+} from './mocks';
 
 jest.mock('ui/chrome', () => ({
   getSavedObjectsClient: jest.fn(),
@@ -17,17 +22,23 @@ jest.mock('../../../../../../src/legacy/core_plugins/data/public/legacy', () => 
   start: {},
   setup: {},
 }));
-jest.mock('./embeddable/embeddable_factory', () => ({ EmbeddableFactory: class Mock {} }));
+jest.mock('./embeddable/embeddable_factory', () => ({
+  EmbeddableFactory: class Mock {
+    setExpressionRenderer() {}
+  },
+}));
 
 describe('editor_frame plugin', () => {
   let pluginInstance: EditorFramePlugin;
   let mountpoint: Element;
-  let pluginDependencies: MockedDependencies;
+  let pluginSetupDependencies: MockedSetupDependencies;
+  let pluginStartDependencies: MockedStartDependencies;
 
   beforeEach(() => {
     pluginInstance = new EditorFramePlugin();
     mountpoint = document.createElement('div');
-    pluginDependencies = createMockDependencies();
+    pluginSetupDependencies = createMockSetupDependencies();
+    pluginStartDependencies = createMockStartDependencies();
   });
 
   afterEach(() => {
@@ -36,7 +47,8 @@ describe('editor_frame plugin', () => {
 
   it('should create an editor frame instance which mounts and unmounts', () => {
     expect(() => {
-      const publicAPI = pluginInstance.setup(null, pluginDependencies);
+      pluginInstance.setup(null, pluginSetupDependencies);
+      const publicAPI = pluginInstance.start(null, pluginStartDependencies);
       const instance = publicAPI.createInstance({});
       instance.mount(mountpoint, {
         onError: jest.fn(),
@@ -49,7 +61,8 @@ describe('editor_frame plugin', () => {
   });
 
   it('should not have child nodes after unmount', () => {
-    const publicAPI = pluginInstance.setup(null, pluginDependencies);
+    pluginInstance.setup(null, pluginSetupDependencies);
+    const publicAPI = pluginInstance.start(null, pluginStartDependencies);
     const instance = publicAPI.createInstance({});
     instance.mount(mountpoint, {
       onError: jest.fn(),

--- a/x-pack/legacy/plugins/lens/public/index.ts
+++ b/x-pack/legacy/plugins/lens/public/index.ts
@@ -20,7 +20,7 @@ import 'uiExports/savedObjectTypes';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { IScope } from 'angular';
 import chrome from 'ui/chrome';
-import { appSetup, appStop } from './app_plugin';
+import { appStart, appSetup, appStop } from './app_plugin';
 import { PLUGIN_ID } from '../common';
 
 // TODO: Convert this to the "new platform" way of doing UI
@@ -31,7 +31,8 @@ function Root($scope: IScope, $element: JQLite) {
     appStop();
   });
 
-  return render(appSetup(), el);
+  appSetup();
+  return render(appStart(), el);
 }
 
 chrome.setRootController(PLUGIN_ID, Root);

--- a/x-pack/legacy/plugins/lens/public/types.ts
+++ b/x-pack/legacy/plugins/lens/public/types.ts
@@ -33,10 +33,13 @@ export interface EditorFrameInstance {
 }
 
 export interface EditorFrameSetup {
-  createInstance: (options: EditorFrameOptions) => EditorFrameInstance;
   // generic type on the API functions to pull the "unknown vs. specific type" error into the implementation
   registerDatasource: <T, P>(name: string, datasource: Datasource<T, P>) => void;
   registerVisualization: <T, P>(visualization: Visualization<T, P>) => void;
+}
+
+export interface EditorFrameStart {
+  createInstance: (options: EditorFrameOptions) => EditorFrameInstance;
 }
 
 // Hints the default nesting to the data source. 0 is the highest priority


### PR DESCRIPTION
It's not strictly necessary to this now, but while we are at it... In your fix you are passing both setup and start dependencies to the setup method of the editor frame plugin. This won't work anymore once we switch to NP world because the start dependencies are only available in the start lifecycle hook.

To represent this in our setup, we have to simulate more of the new platform and separate `start()` and `setup()` lifecycles. This will make it easier to switch because the plugin will already behave as it's working with multiple lifecycle methods.