### PR TITLE
More layout fixes

### DIFF
--- a/src/legacy/core_plugins/expressions/public/np_ready/public/_expression_renderer.scss
+++ b/src/legacy/core_plugins/expressions/public/np_ready/public/_expression_renderer.scss
@@ -12,7 +12,9 @@
   height: 100%;
 }
 
-.expExpressionRenderer-isLoading .expExpressionRenderer__expression,
-.expExpressionRenderer-hasError .expExpressionRenderer__expression {
-  display: none;
+.expExpressionRenderer-isEmpty,
+.expExpressionRenderer-hasError {
+  .expExpressionRenderer__expression {
+    display: none;
+  }
 }

--- a/src/legacy/core_plugins/expressions/public/np_ready/public/expression_renderer.tsx
+++ b/src/legacy/core_plugins/expressions/public/np_ready/public/expression_renderer.tsx
@@ -111,7 +111,7 @@ export const ExpressionRendererImplementation = ({
   }, []);
 
   const classes = classNames('expExpressionRenderer', {
-    'expExpressionRenderer-isLoading': state.isLoading,
+    'expExpressionRenderer-isEmpty': state.isEmpty,
     'expExpressionRenderer-hasError': !!state.error,
   });
 

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/_expression_renderer.scss
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/_expression_renderer.scss
@@ -1,7 +1,12 @@
 .lnsExpressionRenderer {
+  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
   overflow-x: hidden;
   padding: $euiSize;
+
+  > .expExpressionRenderer {
+    position: static; // Let the progress indicator position itself against the outer parent
+  }
 }

--- a/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/_suggestion_panel.scss
+++ b/x-pack/legacy/plugins/lens/public/editor_frame_plugin/editor_frame/_suggestion_panel.scss
@@ -45,12 +45,15 @@
 }
 
 .lnsSuggestionPanel__chartWrapper {
-  position: static; // Let the progress indicator position itself against the button
   display: flex;
   height: 100%;
   width: 100%;
   pointer-events: none;
   padding: $euiSizeS;
+
+  > .expExpressionRenderer {
+    position: static; // Let the progress indicator position itself against the button
+  }
 }
 
 .lnsSuggestionPanel__chartWrapper--withLabel {


### PR DESCRIPTION
- Hide chart if Empty not Loading
- Fix relative positioning for progress bar since className is no longer passed (super hacky)

Even if passing `className` is an "anti-pattern" it **is** an established pattern we use throughout EUI and Kibana and has served us well. Without having this class passed, I now have to target the class of the containing element to remove it's positioning. Usually you don't want to target classes of imported components as who knows when/if those classes could change and then the styles are broken.