### PR TITLE
Fixing scrolling pt. 2

### DIFF
--- a/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.scss
+++ b/x-pack/legacy/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.scss
@@ -26,8 +26,4 @@
   .euiTable {
     background: none;
   }
-
-  .lnsExpressionRenderer {
-    @include euiScrollBar;
-  }
 }

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/_expression_renderer.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/_expression_renderer.scss
@@ -1,4 +1,5 @@
 .lnsExpressionRenderer {
+  @include euiScrollBar;
   position: relative;
   width: 100%;
   height: 100%;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/_workspace_panel_wrapper.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/_workspace_panel_wrapper.scss
@@ -29,6 +29,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      overflow: hidden;
     }
   }
 }


### PR DESCRIPTION
@wylieconlon This fixes those problems I found. I've tested in Chrome, Safari, FF and in Lens Canvas and Dashboard. And checked other Lens charts as well. They all look good. I just couldn't check IE.

<img width="696" alt="Screen Shot 2020-04-17 at 09 55 41 AM" src="https://user-images.githubusercontent.com/549577/79578969-f577b680-8094-11ea-86ab-3a66b0036dad.png">
<img width="690" alt="Screen Shot 2020-04-17 at 09 56 02 AM" src="https://user-images.githubusercontent.com/549577/79578970-f577b680-8094-11ea-8ed5-1a57986922b9.png">
<img width="687" alt="Screen Shot 2020-04-17 at 09 56 11 AM" src="https://user-images.githubusercontent.com/549577/79578972-f6104d00-8094-11ea-8ffa-877904802cc1.png">
<img width="746" alt="Screen Shot 2020-04-17 at 09 54 57 AM" src="https://user-images.githubusercontent.com/549577/79579003-ff99b500-8094-11ea-8658-40267896a9d4.png">
<img width="962" alt="Screen Shot 2020-04-17 at 09 55 05 AM" src="https://user-images.githubusercontent.com/549577/79579004-00324b80-8095-11ea-9cec-4b7089f7badb.png">
