### PR TITLE
Formula signature + doc improvements

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/counter_rate.tsx
@@ -47,6 +47,10 @@ export const counterRateOperation: OperationDefinition<
     defaultMessage: 'Counter rate',
   }),
   input: 'fullReference',
+  description: i18n.translate('xpack.lens.indexPattern.counterRate.description', {
+    defaultMessage:
+      'An aggregation that calculates a rate of documents or a field in each date_histogram bucket.',
+  }),
   selectionStyle: 'field',
   requiredReferences: [
     {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/cumulative_sum.tsx
@@ -45,6 +45,10 @@ export const cumulativeSumOperation: OperationDefinition<
     defaultMessage: 'Cumulative sum',
   }),
   input: 'fullReference',
+  description: i18n.translate('xpack.lens.indexPattern.cumulativeSum.description', {
+    defaultMessage:
+      'An aggregation that calculates the cumulative sum of a specified field in each date_histogram bucket. Cumulative sums always start with 0.',
+  }),
   selectionStyle: 'field',
   requiredReferences: [
     {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/differences.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/differences.tsx
@@ -49,6 +49,10 @@ export const derivativeOperation: OperationDefinition<
     defaultMessage: 'Differences',
   }),
   input: 'fullReference',
+  description: i18n.translate('xpack.lens.indexPattern.derivative.description', {
+    defaultMessage:
+      'An aggregation that calculates the difference over numeric values of a specified field between each pair of date_histogram buckets. Derivative always start with an undefined value for the first bucket, and it requires a minimum of two buckets.',
+  }),
   selectionStyle: 'full',
   requiredReferences: [
     {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/moving_average.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/calculations/moving_average.tsx
@@ -63,13 +63,22 @@ export const movingAverageOperation: OperationDefinition<
   }),
   input: 'fullReference',
   selectionStyle: 'full',
+  description: i18n.translate('xpack.lens.indexPattern.movingAverage.description', {
+    defaultMessage:
+      'Given an ordered series of data, the aggregation will slide a window across the data and emit the average value of that window. The default window value is {defaultValue}',
+    values: {
+      defaultValue: WINDOW_DEFAULT_VALUE,
+    },
+  }),
   requiredReferences: [
     {
       input: ['field', 'managedReference'],
       validateMetadata: (meta) => meta.dataType === 'number' && !meta.isBucketed,
     },
   ],
-  operationParams: [{ name: 'window', type: 'number', required: true }],
+  operationParams: [
+    { name: 'window', type: 'number', required: false, defaultValue: WINDOW_DEFAULT_VALUE },
+  ],
   getPossibleOperation: (indexPattern) => {
     if (hasDateField(indexPattern)) {
       return {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/cardinality.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/cardinality.tsx
@@ -54,6 +54,10 @@ export const cardinalityOperation: OperationDefinition<CardinalityIndexPatternCo
     defaultMessage: 'Unique count',
   }),
   input: 'field',
+  description: i18n.translate('xpack.lens.indexPattern.cardinality.description', {
+    defaultMessage:
+      'A single-value metrics aggregation that calculates an approximate count of distinct values.',
+  }),
   getPossibleOperationForField: ({ aggregationRestrictions, aggregatable, type }) => {
     if (
       supportedTypes.has(type) &&

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/count.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/count.tsx
@@ -33,6 +33,9 @@ export const countOperation: OperationDefinition<CountIndexPatternColumn, 'field
     defaultMessage: 'Count',
   }),
   input: 'field',
+  description: i18n.translate('xpack.lens.indexPattern.count.description', {
+    defaultMessage: 'A metric aggregation that calculates the number of documents.',
+  }),
   getErrorMessage: (layer, columnId, indexPattern) =>
     getInvalidFieldMessage(layer.columns[columnId] as FieldBasedIndexPatternColumn, indexPattern),
   onFieldChange: (oldColumn, field) => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/math_completion.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/math_completion.ts
@@ -6,6 +6,7 @@
  */
 
 import { uniq, startsWith } from 'lodash';
+import { i18n } from '@kbn/i18n';
 import { monaco } from '@kbn/monaco';
 import {
   parse,
@@ -19,6 +20,8 @@ import { IndexPattern } from '../../../../types';
 import { memoizedGetAvailableOperationsByMetadata } from '../../../operations';
 import { tinymathFunctions, groupArgsByType } from '../util';
 import type { GenericOperationDefinition } from '../..';
+import { getFunctionSignatureLabel, getHelpTextContent } from './formula_help';
+import { hasFunctionFieldArgument } from '../validation';
 
 export enum SUGGESTION_TYPE {
   FIELD = 'field',
@@ -212,7 +215,7 @@ function getArgumentSuggestions(
     return { list: [], type: SUGGESTION_TYPE.FIELD };
   }
 
-  if (position > 0 || operation.type === 'count') {
+  if (position > 0 || !hasFunctionFieldArgument(operation.type)) {
     const { namedArguments } = groupArgsByType(ast.args);
     const list = [];
     if (operation.filterable) {
@@ -357,7 +360,7 @@ export function getSuggestion(
         } else {
           const def = operationDefinitionMap[suggestion.label];
           kind = monaco.languages.CompletionItemKind.Constant;
-          if (suggestion.label === 'count' && 'operationParams' in def) {
+          if (!hasFunctionFieldArgument(suggestion.label) && 'operationParams' in def) {
             label = `${label}(${def
               .operationParams!.map((p) => `${p.name}=${p.type}`)
               .join(', ')})`;
@@ -413,6 +416,88 @@ export function getSuggestion(
   };
 }
 
+function getOperationTypeHelp(
+  name: string,
+  operationDefinitionMap: Record<string, GenericOperationDefinition>
+) {
+  const { description, examples } = getHelpTextContent(name, operationDefinitionMap);
+  const descriptionInMarkdown = description.replace(/\n/g, '\n\n');
+  const examplesInMarkdown = `**${i18n.translate('xpack.lens.formulaExampleMarkdown', {
+    defaultMessage: 'Examples',
+  })}**
+
+  ${examples.map((example) => `\`${example}\``).join('\n\n')}`;
+  return {
+    value: `${descriptionInMarkdown}\n\n${examplesInMarkdown}`,
+  };
+}
+
+function getSignaturesForFunction(
+  name: string,
+  operationDefinitionMap: Record<string, GenericOperationDefinition>
+) {
+  if (tinymathFunctions[name]) {
+    const stringify = getFunctionSignatureLabel(name, operationDefinitionMap);
+    const documentation = tinymathFunctions[name].help.replace(/\n/g, '\n\n');
+    return [
+      {
+        label: stringify,
+        documentation: { value: documentation },
+        parameters: tinymathFunctions[name].positionalArguments.map((arg) => ({
+          label: arg.name,
+          documentation: arg.optional
+            ? i18n.translate('xpack.lens.formula.optionalArgument', {
+                defaultMessage: 'Optional. Default value is {defaultValue}',
+                values: {
+                  defaultValue: arg.defaultValue,
+                },
+              })
+            : '',
+        })),
+      },
+    ];
+  }
+  if (operationDefinitionMap[name]) {
+    const def = operationDefinitionMap[name];
+
+    const firstParam: monaco.languages.ParameterInformation | null = hasFunctionFieldArgument(name)
+      ? {
+          label: def.input === 'field' ? 'field' : def.input === 'fullReference' ? 'function' : '',
+        }
+      : null;
+
+    const functionLabel = getFunctionSignatureLabel(name, operationDefinitionMap, firstParam);
+    const documentation = getOperationTypeHelp(name, operationDefinitionMap);
+    if ('operationParams' in def && def.operationParams) {
+      return [
+        {
+          label: functionLabel,
+          parameters: [
+            ...(firstParam ? [firstParam] : []),
+            ...def.operationParams.map((arg) => ({
+              label: `${arg.name}=${arg.type}`,
+              documentation: arg.required
+                ? i18n.translate('xpack.lens.formula.requiredArgument', {
+                    defaultMessage: 'Required',
+                  })
+                : '',
+            })),
+          ],
+          documentation,
+        },
+      ];
+    }
+    return [
+      {
+        label: functionLabel,
+        parameters: firstParam ? [firstParam] : [],
+        documentation,
+      },
+    ];
+  }
+  return [];
+}
+
 export function getSignatureHelp(
   expression: string,
   position: number,
@@ -429,73 +514,16 @@ export function getSignatureHelp(
       // reference equality is fine here because of the way the getInfo function works
       const index = tokenInfo.parent.args.findIndex((arg) => arg === tokenInfo.ast);
 
-      if (tinymathFunctions[name]) {
-        const stringify = `${name}(${tinymathFunctions[name].positionalArguments
-          .map((arg) => arg.name)
-          .join(', ')})`;
+      const signatures = getSignaturesForFunction(name, operationDefinitionMap);
+      if (signatures.length) {
         return {
           value: {
-            signatures: [
-              {
-                label: stringify,
-                parameters: tinymathFunctions[name].positionalArguments.map((arg) => ({
-                  label: arg.name,
-                  documentation: arg.optional ? 'Optional' : '',
-                })),
-              },
-            ],
+            signatures,
             activeParameter: index,
             activeSignature: 0,
           },
           dispose: () => {},
         };
-      } else if (operationDefinitionMap[name]) {
-        const def = operationDefinitionMap[name];
-
-        const firstParam: monaco.languages.ParameterInformation | null =
-          name !== 'count'
-            ? {
-                label:
-                  def.input === 'field' ? 'field' : def.input === 'fullReference' ? 'function' : '',
-              }
-            : null;
-        if ('operationParams' in def) {
-          return {
-            value: {
-              signatures: [
-                {
-                  label: `${name}(${
-                    firstParam ? firstParam.label + ', ' : ''
-                  }${def.operationParams!.map((arg) => `${arg.name}=${arg.type}`)})`,
-                  parameters: [
-                    ...(firstParam ? [firstParam] : []),
-                    ...def.operationParams!.map((arg) => ({
-                      label: `${arg.name}=${arg.type}`,
-                      documentation: arg.required ? 'Required' : '',
-                    })),
-                  ],
-                },
-              ],
-              activeParameter: index,
-              activeSignature: 0,
-            },
-            dispose: () => {},
-          };
-        } else {
-          return {
-            value: {
-              signatures: [
-                {
-                  label: `${name}(${firstParam ? firstParam.label : ''})`,
-                  parameters: firstParam ? [firstParam] : [],
-                },
-              ],
-              activeParameter: index,
-              activeSignature: 0,
-            },
-            dispose: () => {},
-          };
-        }
       }
     }
   } catch (e) {
@@ -519,37 +547,10 @@ export function getHover(
     }
 
     const name = tokenInfo.ast.name;
-
-    if (tinymathFunctions[name]) {
-      const stringify = `${name}(${tinymathFunctions[name].positionalArguments
-        .map((arg) => arg.name)
-        .join(', ')})`;
-      return { contents: [{ value: stringify }] };
-    } else if (operationDefinitionMap[name]) {
-      const def = operationDefinitionMap[name];
-
-      const firstParam: monaco.languages.ParameterInformation | null =
-        name !== 'count'
-          ? {
-              label:
-                def.input === 'field' ? 'field' : def.input === 'fullReference' ? 'function' : '',
-            }
-          : null;
-      if ('operationParams' in def) {
-        return {
-          contents: [
-            {
-              value: `${name}(${
-                firstParam ? firstParam.label + ', ' : ''
-              }${def.operationParams!.map((arg) => `${arg.name}=${arg.type}`)})`,
-            },
-          ],
-        };
-      } else {
-        return {
-          contents: [{ value: `${name}(${firstParam ? firstParam.label : ''})` }],
-        };
-      }
+    const signatures = getSignaturesForFunction(name, operationDefinitionMap);
+    if (signatures.length) {
+      const { label, documentation } = signatures[0];
+      return { contents: [{ value: label }, documentation] };
     }
   } catch (e) {
     // do nothing

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/util.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/util.ts
@@ -73,6 +73,7 @@ export const tinymathFunctions: Record<
     positionalArguments: Array<{
       name: string;
       optional?: boolean;
+      defaultValue?: string | number;
     }>;
     // help: React.ReactElement;
     // Help is in Markdown format
@@ -86,8 +87,12 @@ export const tinymathFunctions: Record<
     ],
     help: `
 Also works with + symbol
-Example: ${'`count() + sum(bytes)`'}
-Example: ${'`add(count(), 5)`'}
+
+**Examples**:
+\`\`\`
+count() + sum(bytes)
+add(count(), 5)
+\`\`\`
     `,
   },
   subtract: {
@@ -117,7 +122,7 @@ Example: ${'`multiply(sum(bytes), 2)`'}
     ],
     help: `
 Also works with ${'`/`'} symbol
-Example: ${'`ceil(sum(bytes))`'}
+Example: ${'`divide(sum(bytes), 2)`'}
     `,
   },
   abs: {
@@ -155,7 +160,7 @@ Example: ${'`ceil(sum(bytes))`'}
     ],
     help: `
 Limits the value from a minimum to maximum
-Example: ${'`ceil(sum(bytes))`'}
+Example: ${'`clamp(sum(bytes), 1, 100)`'}
     `,
   },
   cube: {
@@ -164,7 +169,7 @@ Example: ${'`ceil(sum(bytes))`'}
     ],
     help: `
 Limits the value from a minimum to maximum
-Example: ${'`ceil(sum(bytes))`'}
+Example: ${'`cube(sum(bytes))`'}
     `,
   },
   exp: {
@@ -172,7 +177,7 @@ Example: ${'`ceil(sum(bytes))`'}
       { name: i18n.translate('xpack.lens.formula.expression', { defaultMessage: 'expression' }) },
     ],
     help: `
-Raises <em>e</em> to the nth power.
+Raises *e* to the nth power.
 Example: ${'`exp(sum(bytes))`'}
     `,
   },
@@ -200,12 +205,17 @@ Example: ${'`floor(sum(bytes))`'}
       {
         name: i18n.translate('xpack.lens.formula.base', { defaultMessage: 'base' }),
         optional: true,
+        defaultValue: 'e',
       },
     ],
     help: `
-Logarithm with optional base. The natural base <em>e</em> is used as default.
-Example: ${'`log(sum(bytes))`'}
-Example: ${'`log(sum(bytes), 2)`'}
+Logarithm with optional base. The natural base *e* is used as default.
+
+**Examples**:
+\`\`\`
+log(sum(bytes))
+log(sum(bytes), 2)
+\`\`\`
     `,
   },
   // TODO: check if this is valid for Tinymath
@@ -223,7 +233,6 @@ Example: ${'`log(sum(bytes), 2)`'}
       { name: i18n.translate('xpack.lens.formula.expression', { defaultMessage: 'expression' }) },
       {
         name: i18n.translate('xpack.lens.formula.base', { defaultMessage: 'base' }),
-        optional: true,
       },
     ],
     help: `
@@ -249,12 +258,17 @@ Example: ${'`pow(sum(bytes), 3)`'}
       {
         name: i18n.translate('xpack.lens.formula.decimals', { defaultMessage: 'decimals' }),
         optional: true,
+        defaultValue: 0,
       },
     ],
     help: `
 Rounds to a specific number of decimal places, default of 0
-Example: ${'`round(sum(bytes))`'}
-Example: ${'`round(sum(bytes), 2)`'}
+
+**Examples**:
+\`\`\`
+round(sum(bytes))
+round(sum(bytes), 2)
+\`\`\`
     `,
   },
   sqrt: {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
@@ -606,7 +606,11 @@ export function validateParams(
 }
 
 export function shouldHaveFieldArgument(node: TinymathFunction) {
-  return !['count'].includes(node.name);
+  return hasFunctionFieldArgument(node.name);
+}
+
+export function hasFunctionFieldArgument(type: string) {
+  return !['count'].includes(type);
 }
 
 export function isFirstArgumentValidType(arg: TinymathAST, type: TinymathNodeTypes['type']) {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/index.ts
@@ -186,6 +186,10 @@ interface BaseOperationDefinitionProps<C extends BaseIndexPatternColumn> {
    */
   displayName: string;
   /**
+   * A short description of the operation, useful for help or documentation
+   */
+  description?: string;
+  /**
    * The default label is assigned by the editor
    */
   getDefaultLabel: (
@@ -273,6 +277,7 @@ interface OperationParam {
   name: string;
   type: string;
   required?: boolean;
+  defaultValue?: string | number;
 }
 
 interface FieldlessOperationDefinition<C extends BaseIndexPatternColumn> {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/last_value.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/last_value.tsx
@@ -98,6 +98,10 @@ export const lastValueOperation: OperationDefinition<LastValueIndexPatternColumn
   }),
   getDefaultLabel: (column, indexPattern) => ofName(getSafeName(column.sourceField, indexPattern)),
   input: 'field',
+  description: i18n.translate('xpack.lens.indexPattern.lastValue.description', {
+    defaultMessage:
+      'A single-value metric aggregation that returns the last value (based on time) of the provided field extracted from the aggregated documents.',
+  }),
   onFieldChange: (oldColumn, field) => {
     const newParams = { ...oldColumn.params };
 

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/metrics.tsx
@@ -42,6 +42,7 @@ const supportedTypes = ['number', 'histogram'];
 function buildMetricOperation<T extends MetricColumn<string>>({
   type,
   displayName,
+  description,
   ofName,
   priority,
   optionalTimeScaling,
@@ -51,6 +52,7 @@ function buildMetricOperation<T extends MetricColumn<string>>({
   ofName: (name: string) => string;
   priority?: number;
   optionalTimeScaling?: boolean;
+  description?: string;
 }) {
   const labelLookup = (name: string, column?: BaseIndexPatternColumn) => {
     const label = ofName(name);
@@ -64,6 +66,7 @@ function buildMetricOperation<T extends MetricColumn<string>>({
     type,
     priority,
     displayName,
+    description,
     input: 'field',
     timeScalingMode: optionalTimeScaling ? 'optional' : undefined,
     getPossibleOperationForField: ({ aggregationRestrictions, aggregatable, type: fieldType }) => {
@@ -144,6 +147,10 @@ export const minOperation = buildMetricOperation<MinIndexPatternColumn>({
       defaultMessage: 'Minimum of {name}',
       values: { name },
     }),
+  description: i18n.translate('xpack.lens.indexPattern.min.description', {
+    defaultMessage:
+      'A single-value metrics aggregation that returns the minimum value among the numeric values extracted from the aggregated documents.',
+  }),
 });
 
 export const maxOperation = buildMetricOperation<MaxIndexPatternColumn>({
@@ -156,6 +163,10 @@ export const maxOperation = buildMetricOperation<MaxIndexPatternColumn>({
       defaultMessage: 'Maximum of {name}',
       values: { name },
     }),
+  description: i18n.translate('xpack.lens.indexPattern.max.description', {
+    defaultMessage:
+      'A single-value metrics aggregation that returns the maximum value among the numeric values extracted from the aggregated documents.',
+  }),
 });
 
 export const averageOperation = buildMetricOperation<AvgIndexPatternColumn>({
@@ -169,6 +180,10 @@ export const averageOperation = buildMetricOperation<AvgIndexPatternColumn>({
       defaultMessage: 'Average of {name}',
       values: { name },
     }),
+  description: i18n.translate('xpack.lens.indexPattern.avg.description', {
+    defaultMessage:
+      'A single-value metric aggregation that computes the average of numeric values that are extracted from the aggregated documents',
+  }),
 });
 
 export const sumOperation = buildMetricOperation<SumIndexPatternColumn>({
@@ -183,6 +198,10 @@ export const sumOperation = buildMetricOperation<SumIndexPatternColumn>({
       values: { name },
     }),
   optionalTimeScaling: true,
+  description: i18n.translate('xpack.lens.indexPattern.sum.description', {
+    defaultMessage:
+      'A single-value metrics aggregation that sums up numeric values that are extracted from the aggregated documents.',
+  }),
 });
 
 export const medianOperation = buildMetricOperation<MedianIndexPatternColumn>({
@@ -196,4 +215,8 @@ export const medianOperation = buildMetricOperation<MedianIndexPatternColumn>({
       defaultMessage: 'Median of {name}',
       values: { name },
     }),
+  description: i18n.translate('xpack.lens.indexPattern.median.description', {
+    defaultMessage:
+      'A single-value metrics aggregation that computes the median value that are extracted from the aggregated documents.',
+  }),
 });

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/percentile.tsx
@@ -52,7 +52,16 @@ export const percentileOperation: OperationDefinition<PercentileIndexPatternColu
     defaultMessage: 'Percentile',
   }),
   input: 'field',
-  operationParams: [{ name: 'percentile', type: 'number', required: false }],
+  description: i18n.translate('xpack.lens.indexPattern.percentile.description', {
+    defaultMessage:
+      'A single-metric aggregation that calculates the given percentiles (accepted as argument) over numeric values extracted from the aggregated documents. The default percentile value is {percentile}.',
+    values: {
+      percentile: DEFAULT_PERCENTILE_VALUE,
+    },
+  }),
+  operationParams: [
+    { name: 'percentile', type: 'number', required: false, defaultValue: DEFAULT_PERCENTILE_VALUE },
+  ],
   filterable: true,
   getPossibleOperationForField: ({ aggregationRestrictions, aggregatable, type: fieldType }) => {
     if (supportedFieldTypes.includes(fieldType) && aggregatable && !aggregationRestrictions) {


### PR DESCRIPTION
## Summary

This PR improves the signature popover while hovering and while typing.
Also the documentation has been increased - probably requires to check the compatibility with #13 that I just saw 😓  -.

* Adds more info about types/optionality in the function signature
* Refactor + centralize logic for hover + suggestion and doc in few functions
* Auto-generate examples based on arguments
* Fixed few math documentation informations that were wrong
* Adds and fix some more ES function parameters

I've seen there's a specific component in EUI for markdown, but originally it was using another `Markdown` component. Which one should be the final one?

<img width="684" alt="Screenshot 2021-05-19 at 16 59 51" src="https://user-images.githubusercontent.com/924948/118844929-a28db580-b8cb-11eb-993b-8e49723d8e58.png">
<img width="694" alt="Screenshot 2021-05-19 at 17 00 01" src="https://user-images.githubusercontent.com/924948/118844937-a3bee280-b8cb-11eb-86e8-2ade009331b9.png">
<img width="688" alt="Screenshot 2021-05-19 at 17 00 33" src="https://user-images.githubusercontent.com/924948/118844942-a4577900-b8cb-11eb-8e96-55a67fe5d1bf.png">
<img width="699" alt="Screenshot 2021-05-19 at 17 00 43" src="https://user-images.githubusercontent.com/924948/118844944-a4f00f80-b8cb-11eb-9d3c-60a747af4040.png">
<img width="701" alt="Screenshot 2021-05-19 at 17 01 06" src="https://user-images.githubusercontent.com/924948/118844947-a588a600-b8cb-11eb-8413-26c7503e39af.png">
<img width="690" alt="Screenshot 2021-05-19 at 17 01 44" src="https://user-images.githubusercontent.com/924948/118844957-a6b9d300-b8cb-11eb-9d1b-27bc818511fa.png">
<img width="694" alt="Screenshot 2021-05-19 at 17 01 55" src="https://user-images.githubusercontent.com/924948/118844958-a7526980-b8cb-11eb-9405-628df6f82844.png">
<img width="684" alt="Screenshot 2021-05-19 at 17 12 54" src="https://user-images.githubusercontent.com/924948/118844959-a7eb0000-b8cb-11eb-960d-cb61db539b3e.png">
for
<img width="685" alt="Screenshot 2021-05-19 at 17 17 44" src="https://user-images.githubusercontent.com/924948/118844960-a7eb0000-b8cb-11eb-82e8-2c9b8bc15511.png">mul
<img width="689" alt="Screenshot 2021-05-19 at 17 18 00" src="https://user-images.githubusercontent.com/924948/118844961-a8839680-b8cb-11eb-9bcd-bee7c3f54c26.png">a
<img width="684" alt="Screenshot 2021-05-19 at 17 18 20" src="https://user-images.githubusercontent.com/924948/118844963-a8839680-b8cb-11eb-8640-7a108d7e70e5.png">
<img width="686" alt="Screenshot 2021-05-19 at 17 18 37" src="https://user-images.githubusercontent.com/924948/118844966-a91c2d00-b8cb-11eb-8f34-8bd037f0fa50.png">






### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

