### PR TITLE
[Formula] Add query validation for quotes

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -118,7 +118,7 @@ export function FormulaEditor({
 
       let errors: ErrorWrapper[] = [];
 
-      const { root, error } = tryToParse(text);
+      const { root, error } = tryToParse(text, operationDefinitionMap);
       if (error) {
         errors = [error];
       } else if (root) {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.tsx
@@ -50,7 +50,7 @@ export const formulaOperation: OperationDefinition<
     if (!column.params.formula || !operationDefinitionMap) {
       return;
     }
-    const { root, error } = tryToParse(column.params.formula);
+    const { root, error } = tryToParse(column.params.formula, operationDefinitionMap);
     if (error || !root) {
       return [error!.message];
     }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/parse.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/parse.ts
@@ -28,7 +28,7 @@ function parseAndExtract(
   indexPattern: IndexPattern,
   operationDefinitionMap: Record<string, GenericOperationDefinition>
 ) {
-  const { root, error } = tryToParse(text);
+  const { root, error } = tryToParse(text, operationDefinitionMap);
   if (error || !root) {
     return { extracted: [], isValid: false };
   }


### PR DESCRIPTION
## Summary

This PR adds few more validation level to query parameters:
* when the formula fails to parse, it performs an additional check on the raw text to check the query parameters
* When validating the AST it checks for valid quotes
* when validating the AST it checks that no double queries are submitted (i.e. `count(kql=..., lucene=...)`)

As for now the check if very simple and it is performed at the beginning of the parameter value.
I need to add an additional check at the end of it (at least at AST level).

It is already quite robust from my test, expecially for the worst case (chain of `count` with queries).

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

