### PR TITLE
Improve formula suggestions

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.test.tsx
@@ -867,10 +867,7 @@ describe('IndexPattern Data Source suggestions', () => {
           searchable: true,
         });
 
-        expect(suggestions).toHaveLength(1);
-        // Check that the suggestion is a single metric
-        expect(suggestions[0].table.columns).toHaveLength(1);
-        expect(suggestions[0].table.columns[0].operation.isBucketed).toBeFalsy();
+        expect(suggestions).toHaveLength(0);
       });
 
       it('appends a terms column with default size on string field', () => {
@@ -1023,6 +1020,24 @@ describe('IndexPattern Data Source suggestions', () => {
         });
 
         expect(suggestions).not.toContain(expect.objectContaining({ changeType: 'extended' }));
+      });
+
+      it('skips metric only suggestion when the field is already in use', () => {
+        const initialState = stateWithNonEmptyTables();
+        const suggestions = getDatasourceSuggestionsForField(initialState, '1', {
+          name: 'bytes',
+          displayName: 'bytes',
+          type: 'number',
+          aggregatable: true,
+          searchable: true,
+        });
+
+        expect(
+          suggestions.some(
+            (suggestion) =>
+              suggestion.table.changeType === 'initial' && suggestion.table.columns.length === 1
+          )
+        ).toBeFalsy();
       });
 
       it('skips duplicates when the document-specific field is already in use', () => {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
@@ -254,9 +254,11 @@ function getExistingLayerSuggestionsForField(
     }
   }
 
-  const metricSuggestion = createMetricSuggestion(indexPattern, layerId, state, field);
-  if (metricSuggestion) {
-    suggestions.push(metricSuggestion);
+  if (!fieldInUse) {
+    const metricSuggestion = createMetricSuggestion(indexPattern, layerId, state, field);
+    if (metricSuggestion) {
+      suggestions.push(metricSuggestion);
+    }
   }
 
   return suggestions;

--- a/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/indexpattern_suggestions.ts
@@ -20,6 +20,7 @@ import {
   OperationType,
   getExistingColumnGroups,
   isReferenced,
+  getReferencedColumnIds,
 } from './operations';
 import { hasField } from './utils';
 import {
@@ -582,11 +583,13 @@ function createSuggestionWithDefaultDateHistogram(
 function createSimplifiedTableSuggestions(state: IndexPatternPrivateState, layerId: string) {
   const layer = state.layers[layerId];
 
-  const [
-    availableBucketedColumns,
-    availableMetricColumns,
-    availableReferenceColumns,
-  ] = getExistingColumnGroups(layer);
+  const [availableBucketedColumns, availableMetricColumns] = _.partition(
+    layer.columnOrder,
+    (colId) => layer.columns[colId].isBucketed
+  );
+  const topLevelMetricColumns = availableMetricColumns.filter(
+    (columnId) => !isReferenced(layer, columnId)
+  );
 
   return _.flatten(
     availableBucketedColumns.map((_col, index) => {
@@ -595,46 +598,57 @@ function createSimplifiedTableSuggestions(state: IndexPatternPrivateState, layer
       const allMetricsSuggestion = {
         ...layer,
         columnOrder: [...bucketedColumns, ...availableMetricColumns],
+        noBuckets: false,
       };
 
-      if (availableBucketedColumns.length <= 1 || availableReferenceColumns.length) {
-        // Don't simplify when dealing with single-bucket table. Also don't break
-        // reference-based columns by removing buckets.
+      if (availableBucketedColumns.length <= 1) {
+        // Don't simplify when dealing with single-bucket table.
         return [];
-      } else if (availableMetricColumns.length > 1) {
-        return [{ ...layer, columnOrder: [...bucketedColumns, availableMetricColumns[0]] }];
+      } else if (topLevelMetricColumns.length > 1) {
+        return [
+          {
+            ...layer,
+            columnOrder: [
+              ...bucketedColumns,
+              topLevelMetricColumns[0],
+              ...getReferencedColumnIds(layer, topLevelMetricColumns[0]),
+            ],
+            noBuckets: false,
+          },
+        ];
       } else {
         return allMetricsSuggestion;
       }
     })
   )
     .concat(
-      availableReferenceColumns.length
-        ? []
-        : availableMetricColumns.map((columnId) => {
-            return { ...layer, columnOrder: [columnId] };
-          })
+      topLevelMetricColumns.map((columnId) => {
+        return {
+          ...layer,
+          columnOrder: [columnId, ...getReferencedColumnIds(layer, columnId)],
+          noBuckets: true,
+        };
+      })
     )
-    .map((updatedLayer) => {
+    .map(({ noBuckets, ...updatedLayer }) => {
       return buildSuggestion({
         state,
         layerId,
         updatedLayer,
         changeType: 'reduced',
-        label:
-          updatedLayer.columnOrder.length === 1
-            ? getMetricSuggestionTitle(updatedLayer, availableMetricColumns.length === 1)
-            : undefined,
+        label: noBuckets
+          ? getMetricSuggestionTitle(updatedLayer, availableMetricColumns.length === 1)
+          : undefined,
       });
     });
 }
 
-function getMetricSuggestionTitle(layer: IndexPatternLayer, onlyMetric: boolean) {
+function getMetricSuggestionTitle(layer: IndexPatternLayer, onlySimpleMetric: boolean) {
   const { operationType, label } = layer.columns[layer.columnOrder[0]];
   return i18n.translate('xpack.lens.indexpattern.suggestions.overallLabel', {
     defaultMessage: '{operation} overall',
     values: {
-      operation: onlyMetric ? operationDefinitionMap[operationType].displayName : label,
+      operation: onlySimpleMetric ? operationDefinitionMap[operationType].displayName : label,
     },
     description:
       'Title of a suggested chart containing only a single numerical metric calculated over all available data',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/layer_helpers.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/layer_helpers.ts
@@ -1166,6 +1166,20 @@ export function isReferenced(layer: IndexPatternLayer, columnId: string): boolea
   return allReferences.includes(columnId);
 }
 
+export function getReferencedColumnIds(layer: IndexPatternLayer, columnId: string): string[] {
+  const referencedIds: string[] = [];
+  function collect(id: string) {
+    const column = layer.columns[id];
+    if (column && 'references' in column) {
+      referencedIds.push(...column.references);
+      column.references.forEach(collect);
+    }
+  }
+  collect(columnId);
+
+  return referencedIds;
+}
+
 export function isOperationAllowedAsReference({
   operationType,
   validation,


### PR DESCRIPTION
This PR improves suggestions:

* Do not suggest a single metric if the field is already in use (I think this is what you saw @wylieconlon - if a field is already used and dragged in again, the table will accept it and switch to just metric which doesn't make sense)
* Add reduced suggestions for referenced columns, making sure to not break references. Broken suggestions (like missing date histogram with moving average) are filtered for the suggestion panel, but still used when switching charts. I think this makes sense because it retains as much as it can.