### PR TITLE
[Formula] Clean up operation suggestion system + query validation + query symbols suggestion

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/math_completion.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/math_completion.ts
@@ -312,9 +312,9 @@ export async function getNamedArgumentSuggestions({
   }
 
   const before = ast.value.split(MARKER)[0];
-  // TODO
+
   const suggestions = await data.autocomplete.getQuerySuggestions({
-    language: 'kuery',
+    language: ast.name === 'kql' ? 'kuery' : 'lucene',
     query: ast.value.split(MARKER)[0],
     selectionStart: before.length,
     selectionEnd: before.length,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
@@ -789,6 +789,34 @@ invalid: "
       }
     });
 
+    it('returns an error if formula or math operations are used', () => {
+      const formulaFormulas = ['formula()', 'formula(bytes)', 'formula(formula())'];
+
+      for (const formula of formulaFormulas) {
+        expect(
+          formulaOperation.getErrorMessage!(
+            getNewLayerWithFormula(formula),
+            'col1',
+            indexPattern,
+            operationDefinitionMap
+          )
+        ).toEqual(['Operation formula not found']);
+      }
+
+      const mathFormulas = ['math()', 'math(bytes)', 'math(math())'];
+
+      for (const formula of mathFormulas) {
+        expect(
+          formulaOperation.getErrorMessage!(
+            getNewLayerWithFormula(formula),
+            'col1',
+            indexPattern,
+            operationDefinitionMap
+          )
+        ).toEqual(['Operation math not found']);
+      }
+    });
+
     it('returns an error if field operation in formula have the wrong first argument', () => {
       const formulas = [
         'average(7)',

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
@@ -927,8 +927,29 @@ invalid: "
       ).toEqual(undefined);
     });
 
+    it('returns no error for a query edge case', () => {
+      const formulas = [
+        `count(kql='')`,
+        `count(lucene='')`,
+        `moving_average(count(kql=''), window=7)`,
+      ];
+      for (const formula of formulas) {
+        expect(
+          formulaOperation.getErrorMessage!(
+            getNewLayerWithFormula(formula),
+            'col1',
+            indexPattern,
+            operationDefinitionMap
+          )
+        ).toEqual(undefined);
+      }
+    });
+
     it('returns an error for a query not wrapped in single quotes', () => {
       const formulas = [
+        `count(kql="")`,
+        `count(kql='")`,
+        `count(kql="')`,
         `count(kql="category.keyword: *")`,
         `count(kql='category.keyword: *")`,
         `count(kql="category.keyword: *')`,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.test.tsx
@@ -932,6 +932,9 @@ invalid: "
         `count(kql='')`,
         `count(lucene='')`,
         `moving_average(count(kql=''), window=7)`,
+        `count(kql='bytes >= 4000')`,
+        `count(kql='bytes <= 4000')`,
+        `count(kql='bytes = 4000')`,
       ];
       for (const formula of formulas) {
         expect(

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/formula.tsx
@@ -13,6 +13,7 @@ import { runASTValidation, tryToParse } from './validation';
 import { MemoizedFormulaEditor } from './editor';
 import { regenerateLayerFromAst } from './parse';
 import { generateFormula } from './generate';
+import { filterByVisibleOperation } from './util';
 
 const defaultLabel = i18n.translate('xpack.lens.indexPattern.formulaLabel', {
   defaultMessage: 'Formula',
@@ -50,12 +51,13 @@ export const formulaOperation: OperationDefinition<
     if (!column.params.formula || !operationDefinitionMap) {
       return;
     }
-    const { root, error } = tryToParse(column.params.formula, operationDefinitionMap);
+    const visibleOperationsMap = filterByVisibleOperation(operationDefinitionMap);
+    const { root, error } = tryToParse(column.params.formula, visibleOperationsMap);
     if (error || !root) {
       return [error!.message];
     }
 
-    const errors = runASTValidation(root, layer, indexPattern, operationDefinitionMap);
+    const errors = runASTValidation(root, layer, indexPattern, visibleOperationsMap);
     return errors.length ? errors.map(({ message }) => message) : undefined;
   },
   getPossibleOperation() {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/parse.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/parse.ts
@@ -13,7 +13,12 @@ import { IndexPattern, IndexPatternLayer } from '../../../types';
 import { mathOperation } from './math';
 import { documentField } from '../../../document_field';
 import { runASTValidation, shouldHaveFieldArgument, tryToParse } from './validation';
-import { findVariables, getOperationParams, groupArgsByType } from './util';
+import {
+  filterByVisibleOperation,
+  findVariables,
+  getOperationParams,
+  groupArgsByType,
+} from './util';
 import { FormulaIndexPatternColumn } from './formula';
 import { getColumnOrder } from '../../layer_helpers';
 
@@ -169,7 +174,7 @@ export function regenerateLayerFromAst(
     layer,
     columnId,
     indexPattern,
-    operationDefinitionMap
+    filterByVisibleOperation(operationDefinitionMap)
   );
 
   const columns = { ...layer.columns };

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/util.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/util.ts
@@ -13,7 +13,7 @@ import type {
   TinymathNamedArgument,
   TinymathVariable,
 } from 'packages/kbn-tinymath';
-import type { OperationDefinition, IndexPatternColumn } from '../index';
+import type { OperationDefinition, IndexPatternColumn, GenericOperationDefinition } from '../index';
 import type { GroupedNodes } from './types';
 
 export function groupArgsByType(args: TinymathAST[]) {
@@ -463,4 +463,12 @@ export function findVariables(node: TinymathAST | string): TinymathVariable[] {
     return [node];
   }
   return node.args.flatMap(findVariables);
+}
+
+export function filterByVisibleOperation(
+  operationDefinitionMap: Record<string, GenericOperationDefinition>
+) {
+  return Object.fromEntries(
+    Object.entries(operationDefinitionMap).filter(([, operation]) => !operation.hidden)
+  );
 }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
@@ -136,12 +136,14 @@ export const getRawQueryValidationError = (text: string, operations: Record<stri
 
 const validateQueryQuotes = (rawQuery: string, language: 'kql' | 'lucene') => {
   // check if the raw argument has the minimal requirements
-  const [, rawValue = ''] = rawQuery.split('=');
-  const cleanedRawValue = rawValue.trim();
+  // use the rest operator here to handle cases where comparison operations are used in the query
+  const [, ...rawValue] = rawQuery.split('=');
+  const fullRawValue = (rawValue || ['']).join('');
+  const cleanedRawValue = fullRawValue.trim();
   // it must start with a single quote, and quotes must have a closure
   if (
     cleanedRawValue.length &&
-    (cleanedRawValue[0] !== "'" || !/'\s*([^']+?)\s*'/.test(rawValue)) &&
+    (cleanedRawValue[0] !== "'" || !/'\s*([^']+?)\s*'/.test(fullRawValue)) &&
     // there's a special case when it's valid as two single quote strings
     cleanedRawValue !== "''"
   ) {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
@@ -136,7 +136,7 @@ export const getRawQueryValidationError = (text: string, operations: Record<stri
 
 const validateQueryQuotes = (rawQuery: string, language: 'kql' | 'lucene') => {
   // check if the raw argument has the minimal requirements
-  const [_, rawValue] = rawQuery.split('=');
+  const [, rawValue] = rawQuery.split('=');
   // it must start with a single quote, and quotes must have a closure
   if (rawValue.trim()[0] !== "'" || !/'\s*([^']+?)\s*'/.test(rawValue)) {
     return i18n.translate('xpack.lens.indexPattern.formulaOperationQueryError', {
@@ -391,7 +391,10 @@ function getQueryValidationErrors(
   const errors: ErrorWrapper[] = [];
   (namedArguments ?? []).forEach((arg) => {
     if (arg.name === 'kql' || arg.name === 'lucene') {
-      const message = getQueryValidationError(arg, indexPattern);
+      const message = getQueryValidationError(
+        arg as { value: string; name: 'kql' | 'lucene'; text: string },
+        indexPattern
+      );
       if (message) {
         errors.push({
           message,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/validation.ts
@@ -136,9 +136,15 @@ export const getRawQueryValidationError = (text: string, operations: Record<stri
 
 const validateQueryQuotes = (rawQuery: string, language: 'kql' | 'lucene') => {
   // check if the raw argument has the minimal requirements
-  const [, rawValue] = rawQuery.split('=');
+  const [, rawValue = ''] = rawQuery.split('=');
+  const cleanedRawValue = rawValue.trim();
   // it must start with a single quote, and quotes must have a closure
-  if (rawValue.trim()[0] !== "'" || !/'\s*([^']+?)\s*'/.test(rawValue)) {
+  if (
+    cleanedRawValue.length &&
+    (cleanedRawValue[0] !== "'" || !/'\s*([^']+?)\s*'/.test(rawValue)) &&
+    // there's a special case when it's valid as two single quote strings
+    cleanedRawValue !== "''"
+  ) {
     return i18n.translate('xpack.lens.indexPattern.formulaOperationQueryError', {
       defaultMessage: `Single quotes are required for {language}='' at {rawQuery}`,
       values: { language, rawQuery },


### PR DESCRIPTION
## Summary

This PR add some more features/fixes to the main Formula PR:

* filters up the hidden operations, such `formula` or `math` from being used as valid operations in the formula box.
* fixes an existing bug with the type check.
* fixes query suggestion system to propose more symbols

<img width="462" alt="Screenshot 2021-05-28 at 14 57 39" src="https://user-images.githubusercontent.com/924948/119987464-5aeee400-bfc5-11eb-8ba5-ac6b77b0a020.png">

* adds query validation for quotes (with many test cases)
	* Correctly handles limit cases like `kql=''`
	* Correctly handles multiple equal signs like `kql='a >= b'`

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

