### PR TITLE
[Formula] Add new module to CodeEditor for brackets matching

### DIFF
--- a/packages/kbn-monaco/src/monaco_imports.ts
+++ b/packages/kbn-monaco/src/monaco_imports.ts
@@ -21,5 +21,6 @@ import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js'; // Needed for f
 import 'monaco-editor/esm/vs/editor/contrib/suggest/suggestController.js'; // Needed for suggestions
 import 'monaco-editor/esm/vs/editor/contrib/hover/hover.js'; // Needed for hover
 import 'monaco-editor/esm/vs/editor/contrib/parameterHints/parameterHints.js'; // Needed for signature
+import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/bracketMatching.js'; // Needed for brackets matching highlight
 
 export { monaco };

--- a/src/plugins/kibana_react/public/code_editor/code_editor.tsx
+++ b/src/plugins/kibana_react/public/code_editor/code_editor.tsx
@@ -187,6 +187,7 @@ export class CodeEditor extends React.Component<Props, {}> {
             wordBasedSuggestions: false,
             wordWrap: 'on',
             wrappingIndent: 'indent',
+            matchBrackets: 'never',
             ...options,
           }}
         />

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -455,6 +455,7 @@ export function FormulaEditor({
       wrappingIndent: 'none',
       dimension: { width: 320, height: 200 },
       fixedOverflowWidgets: true,
+      matchBrackets: 'always',
     },
   };
 


### PR DESCRIPTION
## Summary

This PR adds a new module to the Monaco Editor for brackets highlight matching.

<img width="361" alt="Screenshot 2021-05-28 at 12 28 46" src="https://user-images.githubusercontent.com/924948/119971359-26712d00-bfb1-11eb-9140-c4e1a893fbfd.png">
<img width="207" alt="Screenshot 2021-05-28 at 12 29 10" src="https://user-images.githubusercontent.com/924948/119971365-28d38700-bfb1-11eb-8e68-da4e969fd834.png">

Note that this include changes some of the behaviour for other instances of the editor in other plugins/apps.
To avoid any conflict here the default value for brackets matching has been changed to `never` in order to preserve the existing behaviour of no highlight:

Painless editor:
<img width="398" alt="Screenshot 2021-05-28 at 12 31 42" src="https://user-images.githubusercontent.com/924948/119971466-4bfe3680-bfb1-11eb-80a5-8572d0e0bbd2.png">

Runtime editor:
<img width="335" alt="Screenshot 2021-05-28 at 12 32 05" src="https://user-images.githubusercontent.com/924948/119971486-515b8100-bfb1-11eb-8a04-5daaaf7825f7.png">

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

