### PR TITLE
Show warning on losing formula

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -257,7 +257,7 @@ export function FormulaEditor({
     },
     // Make it validate on flyout open in case of a broken formula left over
     // from a previous edit
-    { skipFirstRender: text == null },
+    { skipFirstRender: true },
     256,
     [text]
   );


### PR DESCRIPTION
<img width="441" alt="Screenshot 2021-05-31 at 11 15 44" src="https://user-images.githubusercontent.com/1508364/120170741-92e26b00-c201-11eb-94d4-f209c894d8c5.png">

Show a warning when in temporary quick function mode and there's a formula already.

The warning is only shown if the formula has been changed because otherwise there's not really anything lost (determined whether a setState is called with formula as current operation type). To do this I had to set `skipFirstRender: true` to the state setter effect in the formula editor. Please double-check this change, I think it didn't have bad side-effects but I'm concerned we we would only skip the first render if there is no formula text.