### PR TITLE
Keep quick function around

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/dimension_panel/dimension_editor.tsx
@@ -22,6 +22,7 @@ import {
   EuiTab,
   EuiCallOut,
 } from '@elastic/eui';
+import useUnmount from 'react-use/lib/useUnmount';
 import { IndexPatternDimensionEditorProps } from './dimension_panel';
 import { OperationSupportMatrix } from './operation_support';
 import { IndexPatternColumn } from '../indexpattern';
@@ -40,7 +41,7 @@ import { mergeLayer } from '../state_helpers';
 import { FieldSelect } from './field_select';
 import { hasField, fieldIsInvalid } from '../utils';
 import { BucketNestingEditor } from './bucket_nesting_editor';
-import { IndexPattern, IndexPatternLayer } from '../types';
+import { IndexPattern, IndexPatternLayer, IndexPatternPrivateState } from '../types';
 import { trackUiEvent } from '../../lens_ui_telemetry';
 import { FormatSelector } from './format_selector';
 import { ReferenceEditor } from './reference_editor';
@@ -84,7 +85,7 @@ const LabelInput = ({ value, onChange }: { value: string; onChange: (value: stri
 
 export function DimensionEditor(props: DimensionEditorProps) {
   const {
-    selectedColumn,
+    selectedColumn: upstreamSelectedColumn,
     operationSupportMatrix,
     state,
     columnId,
@@ -106,6 +107,17 @@ export function DimensionEditor(props: DimensionEditorProps) {
   };
   const { fieldByOperation, operationWithoutField } = operationSupportMatrix;
 
+  const [previousQuickFunctionState, setPreviousQuickFunctionState] = useState<
+    IndexPatternPrivateState | undefined
+  >(undefined);
+
+  const [temporaryQuickFunction, setQuickFunction] = useState(false);
+
+  const selectedColumn =
+    temporaryQuickFunction && previousQuickFunctionState
+      ? previousQuickFunctionState.layers[layerId].columns[columnId]
+      : upstreamSelectedColumn;
+
   const selectedOperationDefinition =
     selectedColumn && operationDefinitionMap[selectedColumn.operationType];
 
@@ -113,12 +125,21 @@ export function DimensionEditor(props: DimensionEditorProps) {
     Boolean(selectedOperationDefinition?.type === 'formula')
   );
 
+  useUnmount(() => {
+    if (temporaryQuickFunction && previousQuickFunctionState) {
+      setState(previousQuickFunctionState, {
+        shouldClose: true,
+      });
+    }
+  });
+
   const setStateWrapper = (
     setter: IndexPatternLayer | ((prevLayer: IndexPatternLayer) => IndexPatternLayer),
     shouldClose?: boolean
   ) => {
     if (selectedOperationDefinition?.type === 'formula' && !temporaryQuickFunction) {
       setChangedFormula(true);
+      setPreviousQuickFunctionState(undefined);
     } else {
       setChangedFormula(false);
     }
@@ -151,8 +172,6 @@ export function DimensionEditor(props: DimensionEditorProps) {
   const incompleteField = incompleteInfo?.sourceField ?? null;
 
   const ParamEditor = selectedOperationDefinition?.paramEditor;
-
-  const [temporaryQuickFunction, setQuickFunction] = useState(false);
 
   const possibleOperations = useMemo(() => {
     return Object.values(operationDefinitionMap)
@@ -615,6 +634,7 @@ export function DimensionEditor(props: DimensionEditorProps) {
               onClick={() => {
                 if (selectedColumn?.operationType !== 'formula') {
                   setQuickFunction(false);
+                  setPreviousQuickFunctionState(state);
                   const newLayer = insertOrReplaceColumn({
                     layer: props.state.layers[props.layerId],
                     indexPattern: currentIndexPattern,

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -257,7 +257,7 @@ export function FormulaEditor({
     },
     // Make it validate on flyout open in case of a broken formula left over
     // from a previous edit
-    { skipFirstRender: text == null },
+    { skipFirstRender: true },
     256,
     [text]
   );


### PR DESCRIPTION
Built on top of https://github.com/wylieconlon/kibana/pull/26

This PR keeps the current quick function around for the case to "peek" into formula, then switching back. It stores a reference to the last state before switching to formula in the component. When in temporary quick function mode, it will show the UI as if this last state would be active. If the component is unmounted in this state, it is re-applied (overwriting the formula). If the formula is changed (same logic as the PR #26 ), the quick function state is removed and switching back into temporary quick function mode shows the same screen as usual (nothing selected).

This is not perfect but by keeping this state in the component instead of the global state, it's easy to add and should catch the common user interaction of going to formula, then going back without touching anything.