### PR TITLE
Fix reduced suggestions

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/layer_helpers.ts
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/layer_helpers.ts
@@ -1229,8 +1229,13 @@ export function getReferencedColumnIds(layer: IndexPatternLayer, columnId: strin
   function collect(id: string) {
     const column = layer.columns[id];
     if (column && 'references' in column) {
-      referencedIds.push(...column.references);
-      column.references.forEach(collect);
+      const columnReferences = column.references;
+      // only record references which have created columns yet
+      const existingReferences = columnReferences.filter((reference) =>
+        Boolean(layer.columns[reference])
+      );
+      referencedIds.push(...existingReferences);
+      existingReferences.forEach(collect);
     }
   }
   collect(columnId);


### PR DESCRIPTION
This fixes the problematic cases with reduced suggestions we talked about yesterday.

The issue was about unresolved references in incomplete reference-based columns. This PR filters them for the column order building. Also makes sure to not suggest the same things multiple times for non-bucketed formula