### PR TITLE
Fix responsiveness

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula.scss
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula.scss
@@ -101,7 +101,7 @@
 .lnsFormula__docsContent {
   .lnsFormula__docs--overlay & {
     height: 40vh;
-    width: 65vh;
+    width:  #{'min(65vh, 90vw)'};
   }
 
   .lnsFormula__docs--inline & {

--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_help.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_help.tsx
@@ -224,6 +224,7 @@ function FormulaHelp({
             className="lnsFormula__docsSidebarInner"
             direction="column"
             gutterSize="none"
+            responsive={false}
           >
             <EuiFlexItem className="lnsFormula__docsSearch" grow={false}>
               <EuiFieldSearch


### PR DESCRIPTION
Fixes two responsiveness issues in the formula help popover.

* Flex group being "responsive" and changing from column to row in the wrong place
* Overlay width being bound to screen height which overflows for narrow but tall viewport sizes