### PR TITLE
Fix transposing column crash

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -63,17 +63,25 @@ export function LayerPanels(
     () => (datasourceId: string, newState: unknown) => {
       // React will synchronously update if this is triggered from a third party component,
       // which we don't want. The timeout lets user interaction have priority, then React updates.
-      setTimeout(() => {
-        dispatch({
-          type: 'UPDATE_DATASOURCE_STATE',
-          updater: (prevState: unknown) =>
-            typeof newState === 'function' ? newState(prevState) : newState,
-          datasourceId,
-          clearStagedPreview: false,
-        });
-      }, 0);
+      dispatch({
+        type: 'UPDATE_DATASOURCE_STATE',
+        updater: (prevState: unknown) =>
+          typeof newState === 'function' ? newState(prevState) : newState,
+        datasourceId,
+        clearStagedPreview: false,
+      });
     },
     [dispatch]
+  );
+  const updateDatasourceAsync = useMemo(
+    () => (datasourceId: string, newState: unknown) => {
+      // React will synchronously update if this is triggered from a third party component,
+      // which we don't want. The timeout lets user interaction have priority, then React updates.
+      setTimeout(() => {
+        updateDatasource(datasourceId, newState);
+      }, 0);
+    },
+    [updateDatasource]
   );
   const updateAll = useMemo(
     () => (datasourceId: string, newDatasourceState: unknown, newVisualizationState: unknown) => {
@@ -134,6 +142,7 @@ export function LayerPanels(
             visualizationState={visualizationState}
             updateVisualization={setVisualizationState}
             updateDatasource={updateDatasource}
+            updateDatasourceAsync={updateDatasourceAsync}
             updateAll={updateAll}
             isOnlyLayer={layerIds.length === 1}
             onRemoveLayer={() => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -42,6 +42,7 @@ export function LayerPanel(
     isOnlyLayer: boolean;
     updateVisualization: StateSetter<unknown>;
     updateDatasource: (datasourceId: string, newState: unknown) => void;
+    updateDatasourceAsync: (datasourceId: string, newState: unknown) => void;
     updateAll: (
       datasourceId: string,
       newDatasourcestate: unknown,
@@ -481,7 +482,7 @@ export function LayerPanel(
                             })
                       );
                     } else {
-                      props.updateDatasource(datasourceId, newState);
+                      props.updateDatasourceAsync(datasourceId, newState);
                     }
                     if (!shouldClose) {
                       setActiveDimension({


### PR DESCRIPTION
Transposed columns were broken because the datasource state update became async in all places - in some cases however it's important to keep it in sync with the visualization state update. This PR makes sure only the relevant update is async.