### PR TITLE
[Formula] Make word wrap button show its state

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -68,6 +68,7 @@ export function FormulaEditor({
   >([]);
   const [isHelpOpen, setIsHelpOpen] = useState<boolean>(isFullscreen);
   const [isWarningOpen, setIsWarningOpen] = useState<boolean>(false);
+  const [isWordWrapped, toggleWordWrap] = useState<boolean>(false);
   const editorModel = React.useRef<monaco.editor.ITextModel>();
   const overflowDiv1 = React.useRef<HTMLElement>();
   const disposables = React.useRef<monaco.IDisposable[]>([]);
@@ -482,8 +483,6 @@ export function FormulaEditor({
     []
   );
 
-  const isWordWrapped = editor1.current?.getOption(monaco.editor.EditorOption.wordWrap) !== 'off';
-
   const codeEditorOptions: CodeEditorProps = {
     languageId: LANGUAGE_ID,
     value: text ?? '',
@@ -570,12 +569,9 @@ export function FormulaEditor({
                       isSelected={!isWordWrapped}
                       onClick={() => {
                         editor1.current?.updateOptions({
-                          wordWrap:
-                            editor1.current?.getOption(monaco.editor.EditorOption.wordWrap) ===
-                            'off'
-                              ? 'on'
-                              : 'off',
+                          wordWrap: isWordWrapped ? 'off' : 'on',
                         });
+                        toggleWordWrap(!isWordWrapped);
                       }}
                     />
                   </EuiToolTip>


### PR DESCRIPTION
## Summary

Manage the word wrap state by the react component.

The UI problem was due to the state of `isWordWrapped` managed internally by monaco and not triggering a component rerender.
The editor is now following the component directives on this side.

![lens_formula_word_wrap](https://user-images.githubusercontent.com/924948/120835516-b3ddef80-c564-11eb-9638-4512e22513aa.gif)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

