### PR TITLE
[Formula] Fix cursor move on quote escape

### DIFF
--- a/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/operations/definitions/formula/editor/formula_editor.tsx
@@ -426,7 +426,7 @@ export function FormulaEditor({
           }
 
           let editOperation: monaco.editor.IIdentifiedSingleEditOperation | null = null;
-          let cursorOffset = 2;
+          const cursorOffset = 2;
           if (char === '=') {
             editOperation = {
               range: {
@@ -448,7 +448,6 @@ export function FormulaEditor({
               },
               text: `\\'`,
             };
-            cursorOffset = 3;
           }
 
           if (editOperation) {


### PR DESCRIPTION
## Summary

I noticed the cursor was moving one extra position after the quote escape operation.

Before:

![lens_formula_escape_before](https://user-images.githubusercontent.com/924948/120994795-20373980-c785-11eb-8c0d-9c06d42c8825.gif)

After:
![lens_formula_escape_after](https://user-images.githubusercontent.com/924948/120994812-23cac080-c785-11eb-9c3d-a21c0d8aebfb.gif)


### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

